### PR TITLE
fix(providers): Reduce memory allocation (gc thrash) (#3695)

### DIFF
--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -10,8 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-//nolint:gochecknoglobals
-var invalidSliceBuf = []byte(uuid.NewString())
+var (
+	//nolint:gochecknoglobals
+	invalidSliceBuf = []byte(uuid.NewString())
+	// ErrInvalidOffset checkable error for supplying an invalid offset.
+	ErrInvalidOffset = errors.Errorf("invalid offset")
+)
 
 // Bytes represents a sequence of bytes split into slices.
 type Bytes struct {
@@ -44,13 +48,13 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 	// find the index of starting slice
 	sliceNdx := -1
 
-	for i, p := range b.Slices {
-		if offset < len(p) {
+	for i, bs := range b.Slices {
+		if offset < len(bs) {
 			sliceNdx = i
 			break
 		}
 
-		offset -= len(p)
+		offset -= len(bs)
 	}
 
 	// not found
@@ -118,6 +122,85 @@ func (b Bytes) ReadAt(p []byte, off int64) (n int, err error) {
 type bytesReadSeekCloser struct {
 	b      Bytes
 	offset int
+}
+
+func (b *bytesReadSeekCloser) ReadAt(bs []byte, off int64) (int, error) {
+	b.b.assertValid()
+	// cache "b.b.Slices" - slice parameters will stay constant for duration of
+	// function.  Locking is left to the calling function
+	slices := b.b.Slices
+
+	// source data that is read will be written to w, the buffer backed by p.
+	offset := off
+
+	maxBsIndex := len(bs)
+
+	// negative offsets result in an error
+	if offset < 0 {
+		return 0, ErrInvalidOffset
+	}
+
+	sliceNdx := -1
+
+	// find the index of starting slice
+	for i, slicesBuf := range slices {
+		if offset < int64(len(slicesBuf)) {
+			sliceNdx = i
+			break
+		}
+
+		// update offset to be relative to the sliceNdx slice
+		offset -= int64(len(slicesBuf))
+	}
+
+	// no slice found if sliceNdx is still negative
+	if sliceNdx == -1 {
+		// return no bytes read if the buffer has no length
+		if maxBsIndex == 0 {
+			return 0, nil
+		}
+
+		return 0, io.EOF
+	}
+
+	// save off our working slice as curSlice
+	curSlice := slices[sliceNdx]
+
+	// copy the requested bytes from curSlice into bs (reader output)
+	m := copy(bs, curSlice[offset:])
+	// accounting: keep track of total number of bytes written in n and
+	// number of bytes written from the current slice in m
+	n := m
+
+	// move on to next and then check if all slices were consumed
+	sliceNdx++
+
+	slicesN := len(slices)
+
+	// while there are more bytes to read (maxBsIndex > n) and there are more
+	// slices left (sliceNdx < slicesN)
+	for maxBsIndex > n && sliceNdx < slicesN {
+		// get a new working slice
+		curSlice = slices[sliceNdx]
+
+		// copy what we can from the current slice into our destination.
+		// (no need to keep track of offset within curSlice)
+		m = copy(bs[n:], curSlice)
+		// keep track of total number of bytes written in n and
+		// number of bytes written from the current slice in m
+		n += m
+
+		// move on to next and then check if all slices were consumed
+		sliceNdx++
+	}
+
+	// if we have run out of slices but the input buffer is still not
+	// consumed completely then it means we have hit an EOF
+	if sliceNdx == slicesN && m == len(curSlice) {
+		return n, io.EOF
+	}
+
+	return n, nil
 }
 
 func (b *bytesReadSeekCloser) Close() error {

--- a/internal/gather/gather_bytes_test.go
+++ b/internal/gather/gather_bytes_test.go
@@ -2,7 +2,9 @@ package gather
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"math"
 	"testing"
 	"testing/iotest"
 
@@ -161,6 +163,13 @@ func TestGatherBytesReadSeeker(t *testing.T) {
 	reader := tmp.inner.Reader()
 	defer reader.Close() //nolint:errcheck
 
+	// TestReader tests that reading from r returns the expected file content.
+	// It does reads of different sizes, until EOF.
+	// If r implements [io.ReaderAt] or [io.Seeker], TestReader also checks
+	// that those operations behave as they should.
+	//
+	// If TestReader finds any misbehaviors, it returns an error reporting them.
+	// The error text may span multiple lines.
 	require.NoError(t, iotest.TestReader(reader, buf))
 
 	_, err := reader.Seek(-3, io.SeekStart)
@@ -171,6 +180,156 @@ func TestGatherBytesReadSeeker(t *testing.T) {
 
 	_, err = reader.Seek(10000000, io.SeekCurrent)
 	require.Error(t, err)
+}
+
+func TestGatherBytesReaderAtErrorResponses(t *testing.T) {
+	// 3.7 times the internal chunk size
+	contentBuf := make([]byte, int(float64(defaultAllocator.chunkSize)*3.7))
+	for i := range contentBuf {
+		contentBuf[i] = uint8(i % math.MaxUint8)
+	}
+
+	tcs := []struct {
+		inBsLen   int
+		inOff     int64
+		expectErr error
+		expectN   int
+	}{
+		{
+			inBsLen:   1 << 10,
+			inOff:     -1,
+			expectErr: ErrInvalidOffset,
+			expectN:   0,
+		},
+		{
+			inBsLen:   1 << 10,
+			inOff:     math.MaxInt64,
+			expectErr: io.EOF,
+			expectN:   0,
+		},
+		{
+			inBsLen:   0,
+			inOff:     -1,
+			expectErr: ErrInvalidOffset,
+			expectN:   0,
+		},
+		{
+			inBsLen: 0,
+			inOff:   math.MaxInt64,
+			expectN: 0,
+		},
+	}
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("%d: %d %d %d", i, tc.inBsLen, tc.inOff, tc.expectN), func(t *testing.T) {
+			// tmp is an empty buffer that will supply some bytes
+			// for testing
+			var wrt WriteBuffer
+			defer wrt.Close()
+
+			wrt.Append(contentBuf)
+			require.Equalf(t, defaultAllocator.chunkSize, wrt.alloc.chunkSize,
+				"this test expects that the default-allocator will be used, but we are using: %#v", wrt.alloc)
+
+			// get the reader out of the WriteBuffer so we can read what was written
+			// (presume all 0s)
+			reader := wrt.inner.Reader()
+			defer reader.Close() //nolint:errcheck
+
+			// get the reader as a ReaderAt
+			readerAt := reader.(io.ReaderAt)
+
+			// make an output buffer of the required length
+			bs := make([]byte, tc.inBsLen)
+
+			n, err := readerAt.ReadAt(bs, tc.inOff)
+			require.ErrorIs(t, err, tc.expectErr)
+			require.Equal(t, tc.expectN, n)
+		})
+	}
+}
+
+func TestGatherBytesReaderAtVariableInputBufferSizes(t *testing.T) {
+	const inputBufferMaxMultiplier = 4.0 // maximum number of times the internal chunk size
+
+	contentBuf := make([]byte, defaultAllocator.chunkSize*inputBufferMaxMultiplier)
+	for i := range contentBuf {
+		contentBuf[i] = uint8(i % math.MaxUint8)
+	}
+
+	type testCase struct {
+		name            string
+		inputBufferSize int
+	}
+
+	// Test some interesting input buffer sizes from a 1-byte buffer to many
+	// multiples of the internal allocator chunk size.
+	testCases := []testCase{
+		{"1", 1},
+		{"0.5x", int(0.5 * float64(defaultAllocator.chunkSize))},
+
+		{"x-1", defaultAllocator.chunkSize - 1},
+		{"x", defaultAllocator.chunkSize},
+		{"x+1", defaultAllocator.chunkSize + 1},
+		{"1.5x", int(1.5 * float64(defaultAllocator.chunkSize))},
+
+		{"2x-1", 2*defaultAllocator.chunkSize - 1},
+		{"2x", 2 * defaultAllocator.chunkSize},
+		{"2x+1", 2*defaultAllocator.chunkSize + 1},
+		{"2.5x", int(2.5 * float64(defaultAllocator.chunkSize))},
+
+		{"3x-1", 3*defaultAllocator.chunkSize - 1},
+		{"3x", 3 * defaultAllocator.chunkSize},
+		{"3x+1", 3*defaultAllocator.chunkSize + 1},
+
+		{"4x-1", 4*defaultAllocator.chunkSize - 1},
+		{"4x", 4 * defaultAllocator.chunkSize},
+	}
+
+	// Test the third buffer slice. The idea here is to exercise the part of
+	// the buffer ReaderAt implementation where it has a longer buffer size
+	// than the size of the internal chunks of the buffer implementation. When
+	// we do this, the ReaderAt is forced to draw more data than it actually
+	// can from the first slice it found after searching for the current
+	// pointer in read cycle. Finally, it should increment the read index
+	// correctly.
+	//
+	// x.1 ... x.9
+	for chunkSizeMultiplier := inputBufferMaxMultiplier - 0.9; chunkSizeMultiplier < inputBufferMaxMultiplier; chunkSizeMultiplier += 0.1 {
+		testCases = append(testCases, testCase{
+			fmt.Sprintf("%.1fx", chunkSizeMultiplier),
+			int(float64(defaultAllocator.chunkSize) * chunkSizeMultiplier),
+		},
+		)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// each test should have its own writer because t.Run() can be
+			// parallelized
+			var preWrt WriteBuffer
+			defer preWrt.Close()
+
+			// assert some preconditions that the reader conforms to ReaderAt
+			buf := contentBuf[:tc.inputBufferSize]
+
+			// write the generated data
+			n, err := preWrt.Write(buf)
+			require.NoErrorf(t, err, "Write() faiiled, inputBufferSize: %8", tc.inputBufferSize)
+			require.Equalf(t, defaultAllocator.chunkSize, preWrt.alloc.chunkSize,
+				"this test expects that the default-allocator will be used, but we are using: %#v", preWrt.alloc)
+
+			require.Lenf(t, buf, n, "unexpected size of data written, inputBufferSize: %d", tc.inputBufferSize)
+
+			// get the reader out of the WriteBuffer so we can read what was written
+			preRdr := preWrt.inner.Reader()
+			_, ok := preRdr.(io.ReaderAt)
+			require.Truef(t, ok, "MUST implement io.ReaderAt, inputBufferSize: %d", tc.inputBufferSize)
+
+			// execute standard ReadAt tests.
+			require.NoErrorf(t, iotest.TestReader(preRdr, buf),
+				"iotest failed, inputBufferSize: %d", tc.inputBufferSize)
+		})
+	}
 }
 
 func TestGatherBytesPanicsOnClose(t *testing.T) {


### PR DESCRIPTION
Avoid minio allocations by implementing `ReadAt` function. This change causes Minio libraries to reduce memory allocations. Specifically, buffer allocations for S3 upload.
Add tests for new functionality.

---------