### PR TITLE
refactor(general): Increase restore progress granularity (#3655)

### DIFF
--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -259,4 +259,124 @@ func (p *cliProgress) Finish() {
 	}
 }
 
+type cliRestoreProgress struct {
+	restoredCount      atomic.Int32
+	enqueuedCount      atomic.Int32
+	skippedCount       atomic.Int32
+	ignoredErrorsCount atomic.Int32
+
+	restoredTotalFileSize atomic.Int64
+	enqueuedTotalFileSize atomic.Int64
+	skippedTotalFileSize  atomic.Int64
+
+	progressUpdateInterval time.Duration
+	enableProgress         bool
+
+	svc            appServices
+	outputThrottle timetrack.Throttle
+	outputMutex    sync.Mutex
+	out            textOutput
+	eta            timetrack.Estimator
+
+	// +checklocks:outputMutex
+	lastLineLength int
+}
+
+func (p *cliRestoreProgress) setup(svc appServices, _ *kingpin.Application) {
+	cp := svc.getProgress()
+	if cp == nil {
+		return
+	}
+
+	p.progressUpdateInterval = cp.progressUpdateInterval
+	p.enableProgress = cp.enableProgress
+	p.out = cp.out
+	p.svc = svc
+
+	p.eta = timetrack.Start()
+}
+
+func (p *cliRestoreProgress) SetCounters(
+	enqueuedCount, restoredCount, skippedCount, ignoredErrors int32,
+	enqueuedBytes, restoredBytes, skippedBytes int64,
+) {
+	p.enqueuedCount.Store(enqueuedCount)
+	p.enqueuedTotalFileSize.Store(enqueuedBytes)
+
+	p.restoredCount.Store(restoredCount)
+	p.restoredTotalFileSize.Store(restoredBytes)
+
+	p.skippedCount.Store(skippedCount)
+	p.skippedTotalFileSize.Store(skippedBytes)
+
+	p.ignoredErrorsCount.Store(ignoredErrors)
+
+	p.maybeOutput()
+}
+
+func (p *cliRestoreProgress) Flush() {
+	p.outputThrottle.Reset()
+	p.output("\n")
+}
+
+func (p *cliRestoreProgress) maybeOutput() {
+	if p.outputThrottle.ShouldOutput(p.svc.getProgress().progressUpdateInterval) {
+		p.output("")
+	}
+}
+
+func (p *cliRestoreProgress) output(suffix string) {
+	if !p.svc.getProgress().enableProgress {
+		return
+	}
+
+	p.outputMutex.Lock()
+	defer p.outputMutex.Unlock()
+
+	restoredCount := p.restoredCount.Load()
+	enqueuedCount := p.enqueuedCount.Load()
+	skippedCount := p.skippedCount.Load()
+	ignoredCount := p.ignoredErrorsCount.Load()
+
+	restoredSize := p.restoredTotalFileSize.Load()
+	enqueuedSize := p.enqueuedTotalFileSize.Load()
+	skippedSize := p.skippedTotalFileSize.Load()
+
+	if restoredSize == 0 {
+		return
+	}
+
+	var maybeRemaining, maybeSkipped, maybeErrors string
+	if est, ok := p.eta.Estimate(float64(restoredSize), float64(enqueuedSize)); ok {
+		maybeRemaining = fmt.Sprintf(" %v (%.1f%%) remaining %v",
+			units.BytesPerSecondsString(est.SpeedPerSecond),
+			est.PercentComplete,
+			est.Remaining)
+	}
+
+	if skippedCount > 0 {
+		maybeSkipped = fmt.Sprintf(", skipped %v (%v)", skippedCount, units.BytesString(skippedSize))
+	}
+
+	if ignoredCount > 0 {
+		maybeErrors = fmt.Sprintf(", ignored %v errors", ignoredCount)
+	}
+
+	line := fmt.Sprintf("Processed %v (%v) of %v (%v)%v%v%v.",
+		restoredCount+skippedCount, units.BytesString(restoredSize),
+		enqueuedCount, units.BytesString(enqueuedSize),
+		maybeSkipped, maybeErrors, maybeRemaining,
+	)
+
+	var extraSpaces string
+
+	if len(line) < p.lastLineLength {
+		// add extra spaces to wipe over previous line if it was longer than current
+		extraSpaces = strings.Repeat(" ", p.lastLineLength-len(line))
+	}
+
+	p.lastLineLength = len(line)
+	p.out.printStderr("\r%v%v%v", line, extraSpaces, suffix)
+}
+
 var _ snapshotfs.UploadProgress = (*cliProgress)(nil)

--- a/snapshot/restore/restore_progress.go
+++ b/snapshot/restore/restore_progress.go
@@ -1,0 +1,10 @@
+package restore
+
+// Progress is invoked by copier to report status of snapshot restoration.
+type Progress interface {
+	SetCounters(
+		enqueuedCount, restoredCount, skippedCount, ignoredErrors int32,
+		enqueuedBytes, restoredBytes, skippedBytes int64,
+	)
+	Flush()
+}

--- a/snapshot/restore/shallow_fs_output.go
+++ b/snapshot/restore/shallow_fs_output.go
@@ -49,7 +49,7 @@ func (o *ShallowFilesystemOutput) WriteDirEntry(ctx context.Context, relativePat
 }
 
 // WriteFile implements restore.Output interface.
-func (o *ShallowFilesystemOutput) WriteFile(ctx context.Context, relativePath string, f fs.File) error {
+func (o *ShallowFilesystemOutput) WriteFile(ctx context.Context, relativePath string, f fs.File, _ FileWriteProgress) error {
 	log(ctx).Debugf("(Shallow) WriteFile %v (%v bytes) %v, %v", filepath.Join(o.TargetPath, relativePath), f.Size(), f.Mode(), f.ModTime())
 
 	mde, ok := f.(snapshot.HasDirEntry)
@@ -61,7 +61,7 @@ func (o *ShallowFilesystemOutput) WriteFile(ctx context.Context, relativePath st
 
 	// Write small files directly instead of writing placeholders.
 	if de.FileSize < int64(o.MinSizeForPlaceholder) {
-		return o.FilesystemOutput.WriteFile(ctx, relativePath, f)
+		return o.FilesystemOutput.WriteFile(ctx, relativePath, f, nil)
 	}
 
 	placeholderpath, err := o.writeShallowEntry(ctx, relativePath, de)

--- a/snapshot/restore/tar_output.go
+++ b/snapshot/restore/tar_output.go
@@ -69,7 +69,7 @@ func (o *TarOutput) Close(ctx context.Context) error {
 }
 
 // WriteFile implements restore.Output interface.
-func (o *TarOutput) WriteFile(ctx context.Context, relativePath string, f fs.File) error {
+func (o *TarOutput) WriteFile(ctx context.Context, relativePath string, f fs.File, _ FileWriteProgress) error {
 	r, err := f.Open(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error opening file")

--- a/snapshot/restore/zip_output.go
+++ b/snapshot/restore/zip_output.go
@@ -55,7 +55,7 @@ func (o *ZipOutput) Close(ctx context.Context) error {
 }
 
 // WriteFile implements restore.Output interface.
-func (o *ZipOutput) WriteFile(ctx context.Context, relativePath string, f fs.File) error {
+func (o *ZipOutput) WriteFile(ctx context.Context, relativePath string, f fs.File, _ FileWriteProgress) error {
 	r, err := f.Open(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error opening file")

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -13,12 +13,15 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/internal/diff"
 	"github.com/kopia/kopia/internal/fshasher"
@@ -38,6 +41,42 @@ const (
 	overriddenFilePermissions = 0o651
 	overriddenDirPermissions  = 0o752
 )
+
+type restoreProgressInvocation struct {
+	enqueuedCount, restoredCount, skippedCount, ignoredErrors int32
+	enqueuedBytes, restoredBytes, skippedBytes                int64
+}
+
+type fakeRestoreProgress struct {
+	mtx                  sync.Mutex
+	invocations          []restoreProgressInvocation
+	flushesCount         int
+	invocationAfterFlush bool
+}
+
+func (p *fakeRestoreProgress) SetCounters(
+	enqueuedCount, restoredCount, skippedCount, ignoredErrors int32,
+	enqueuedBytes, restoredBytes, skippedBytes int64,
+) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.invocations = append(p.invocations, restoreProgressInvocation{
+		enqueuedCount: enqueuedCount,
+		restoredCount: restoredCount,
+		skippedCount:  skippedCount,
+		ignoredErrors: ignoredErrors,
+		enqueuedBytes: enqueuedBytes,
+		restoredBytes: restoredBytes,
+		skippedBytes:  skippedBytes,
+	})
+	if p.flushesCount > 0 {
+		p.invocationAfterFlush = true
+	}
+}
+
+func (p *fakeRestoreProgress) Flush() {
+	p.flushesCount++
+}
 
 func TestRestoreCommand(t *testing.T) {
 	t.Parallel()
@@ -82,7 +121,26 @@ func TestRestoreCommand(t *testing.T) {
 
 	// Attempt to restore using snapshot ID
 	restoreFailDir := testutil.TempDirectory(t)
-	e.RunAndExpectSuccess(t, "restore", snapID, restoreFailDir)
+
+	// Remember original app cusomization
+	origCustomizeApp := runner.CustomizeApp
+
+	// Prepare fake restore progress and set it when needed
+	frp := &fakeRestoreProgress{}
+
+	runner.CustomizeApp = func(a *cli.App, kp *kingpin.Application) {
+		origCustomizeApp(a, kp)
+		a.SetRestoreProgress(frp)
+	}
+
+	e.RunAndExpectSuccess(t, "restore", snapID, restoreFailDir, "--progress-update-interval", "1ms")
+
+	runner.CustomizeApp = origCustomizeApp
+
+	// Expecting progress to be reported multiple times and flush to be invoked at the end
+	require.Greater(t, len(frp.invocations), 2, "expected multiple reports of progress")
+	require.Equal(t, 1, frp.flushesCount, "expected to have progress flushed once")
+	require.False(t, frp.invocationAfterFlush, "expected not to have reports after flush")
 
 	// Restore last snapshot
 	restoreDir := testutil.TempDirectory(t)


### PR DESCRIPTION
When restoring huge file(s), the progress reporting is done in a bit weird way:

```
kopia_test % kopia snapshot restore ka2084d263182164b6cf3456668e6b6da /Users/eugen.sumin/kopia_test/2
Restoring to local filesystem (/Users/eugen.sumin/kopia_test/2) with parallelism=8...
Processed 6 (5.4 GB) of 5 (5.4 GB) 1.6 MB/s (100.0%) remaining 0s.
Processed 6 (5.4 GB) of 5 (5.4 GB) 1.6 MB/s (100.0%) remaining 0s.
Processed 6 (5.4 GB) of 5 (5.4 GB) 1.6 MB/s (100.0%) remaining 0s.
Processed 6 (5.4 GB) of 5 (5.4 GB) 1.5 MB/s (100.0%) remaining 0s.
Processed 6 (5.4 GB) of 5 (5.4 GB) 1.5 MB/s (100.0%) remaining 0s.
Processed 6 (5.4 GB) of 5 (5.4 GB) 1.5 MB/s (100.0%) remaining 0s.
Restored 5 files, 1 directories and 0 symbolic links (5.4 GB).
```
In fact, the amount of restored data is dumped when particular file completely restored.

This PR contains the least invasive change, which allows us to see progress update while file is downloaded from object storage.
```
Restoring to local filesystem (/Users/eugen.sumin/kopia_test/55) with parallelism=8...
Processed 2 (3.1 MB) of 5 (1.8 GB).
Processed 4 (459.6 MB) of 5 (1.8 GB) 270.3 MB/s (25.2%) remaining 4s.
Processed 4 (468.7 MB) of 5 (1.8 GB) 269 MB/s (25.7%) remaining 4s.
Processed 4 (741.6 MB) of 5 (1.8 GB) 269 MB/s (40.6%) remaining 3s.
Processed 4 (1.1 GB) of 5 (1.8 GB) 280 MB/s (57.6%) remaining 2s.
Processed 5 (1.4 GB) of 5 (1.8 GB) 291.1 MB/s (75.2%) remaining 1s.
Processed 5 (1.4 GB) of 5 (1.8 GB) 289.8 MB/s (75.6%) remaining 1s.
Processed 5 (1.6 GB) of 5 (1.8 GB) 270.2 MB/s (85.3%) remaining 0s.
Processed 5 (1.7 GB) of 5 (1.8 GB) 256.3 MB/s (95.0%) remaining 0s.
Processed 6 (1.8 GB) of 5 (1.8 GB) 251 MB/s (100.0%) remaining 0s.
Processed 6 (1.8 GB) of 5 (1.8 GB) 251 MB/s (100.0%) remaining 0s.
Restored 5 files, 1 directories and 0 symbolic links (1.8 GB).
```

---------